### PR TITLE
Add --verbose option to phpunit test runner

### DIFF
--- a/testing/unit-coverage.sh
+++ b/testing/unit-coverage.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-__SHOPWARE_ROOT__vendor/phpunit/phpunit/phpunit --coverage-html=$HOME/plugin-coverage/__PLUGIN__
+__SHOPWARE_ROOT__vendor/phpunit/phpunit/phpunit --coverage-html=$HOME/plugin-coverage/__PLUGIN__ --verbose

--- a/testing/unit.sh
+++ b/testing/unit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-__SHOPWARE_ROOT__vendor/phpunit/phpunit/phpunit
+__SHOPWARE_ROOT__vendor/phpunit/phpunit/phpunit --verbose


### PR DESCRIPTION
Displays skipped tests error messages. 
This is useful i.e. to see if tests were skipped if a plugin is not installed for compatibility tests